### PR TITLE
SQ V8.0 compatible version - with Java8 nio bytebuffer API mismatch fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.codehaus.sonar</groupId>
   <artifactId>sonar-text-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
 
   <name>Sonar Text Plugin</name>
 


### PR DESCRIPTION
Only change is the compiler option that'll fix the API mismatch that occurs when you run the scanner under Java 8