### PR TITLE
Fix for the Java 11 compile -> Java 8 runtime API issue 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.codehaus.sonar</groupId>
   <artifactId>sonar-text-plugin</artifactId>
   <packaging>sonar-plugin</packaging>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
 
   <name>Sonar Text Plugin</name>
 
@@ -101,7 +101,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
           <source>${jdk.source.version}</source>
           <target>${jdk.target.version}</target>

--- a/src/main/java/org/sonar/plugins/text/TextPlugin.java
+++ b/src/main/java/org/sonar/plugins/text/TextPlugin.java
@@ -8,7 +8,7 @@ public final class TextPlugin implements Plugin {
 
   public static final String MY_PROPERTY = "sonar.example.myproperty";
   public static final String FILE_SUFFIXES_KEY = "sonar-text-plugin.file.suffixes";
-  public static final String SONAR_WAY_PROFILE_NAME = "Sonar Text Plugin way";
+  public static final String SONAR_WAY_PROFILE_NAME = "Community Text Plugin way";
   public static final String SONAR_WAY_JSON_FILE_PATH = "org/sonar/l10n/text/default_quality_profile/Sonar_way_profile.json";
 
   @Override

--- a/src/main/java/org/sonar/plugins/text/batch/TextIssueSensor.java
+++ b/src/main/java/org/sonar/plugins/text/batch/TextIssueSensor.java
@@ -50,7 +50,7 @@ public class TextIssueSensor implements Sensor {
 
   @Override
   public void describe(SensorDescriptor descriptor) {
-    descriptor.name("Inspects the project's files using custom rules built from regular expressions for known combinations of problematic configurations and/or code.");
+    descriptor.name("Community text plugin (sonar-text-plugin)");
     descriptor.createIssuesForRuleRepositories(TextRulesDefinition.REPOSITORY_KEY);
   }
 


### PR DESCRIPTION
1. Now using a maven-compiler-plugin that honors "maven.compiler.release" to address the Java 11 compile -> Java 8 runtime API issue.
2. Adjusted the name of the plugin's default sonar quality profile.
3. Adjusted the sensor's descriptor so that when gets printed by the scanner fits that usage context.